### PR TITLE
Update parse_csv.py and parse_fairness.py output file name

### DIFF
--- a/model/parse_csv.py
+++ b/model/parse_csv.py
@@ -105,11 +105,9 @@ def parse_csv(flp, out_dir, rtt_window):
         # Loss rate
         output[i][3] = len(loss_queue) / float(len(loss_queue) + len(packet_queue))
 
-    # Write the array to output file
-    print("Saving " + out_dir + "/" + path.basename(flp)[:-4] + "-" + str(rtt_window) 
-        + "rttW-1flowNum-csv.npz")
-    np.savez_compressed(out_dir + "/" + path.basename(flp)[:-4] + "-" + str(rtt_window) 
-        + "rttW-1flowNum-csv.npz", output)
+    out_flp = path.join(out_dir, f"{path.basename(flp)[:-4]}-{rtt_window}rttW-1flowNum-csv.npz")
+    print("Saving " + out_flp)
+    np.savez_compressed(out_flp, output)
 
 def main():
     # Parse command line arguments.

--- a/model/parse_fairness.py
+++ b/model/parse_fairness.py
@@ -113,11 +113,9 @@ def parse_pcap(flp, out_dir, rtt_window):
             output_array[port] = np.vstack([output_array[port], [pkts[i][1][scapy.layers.inet.TCP].seq, queue_occupency]])
 
     for i in range(unfair_flows):
-        print("Saving " + out_dir + "/" + path.basename(flp)[:-9] + "-" + 
-            str(rtt_window) + "rttW-" + str(i+1) + "flowNum-fairness.npz")
-        np.savez_compressed(out_dir + "/" + path.basename(flp)[:-9] + "-" + 
-            str(rtt_window) + "rttW-" + str(i+1) + "flowNum-fairness.npz", 
-            output_array[SPORT_OFFSET + i])
+        out_flp = path.join(out_dir, f"{path.basename(flp)[:-9]}-{rtt_window}rttW-{i+1}flowNum-fairness.npz")
+        print("Saving " + out_flp)
+        np.savez_compressed(out_flp, output_array[SPORT_OFFSET + i])
 
 
 def main():


### PR DESCRIPTION
For example, parse_csv.py will produce -
4Mbps-400us-1p-1unfair-4other-1380B-80s-2rttW-1flowNum-csv.npz

2rttW - 2 RTT window
1flowNum - unfair flow number 1 (in case we have multiple unfair flows in the future) 

and parse_fairness will produce -
4Mbps-400us-1p-1unfair-4other-1380B-80s-2rttW-1flowNum-fairness.npz

parse_fairness could produce multiple files if there're multiple unfair flows, while parse_csv only produce one output file since one csv file corresponds to one unfair flow.

Testing:
Tested both scripts with simulation results in /data/ directory

TODO:
Update hard-coded "1flowNum" in parse_csv
Will squash these commits into one when merging into master