### PR TITLE
Optimize parse_dumbbell to reduce memory usage

### DIFF
--- a/model/parse_dumbbell.py
+++ b/model/parse_dumbbell.py
@@ -111,7 +111,7 @@ def parse_pcap(flp, out_dir, rtt_window):
 
     # Process pcap files from routers to determine queue occupency
     # (sender, timestamp)
-    router_pkts = parse_packets_endpoint(flp, packet_size_B)
+    router_pkts = parse_packets_router(flp, packet_size_B)
 
     # Number of packets sent by the unfair flows within RTT window
     # Note that RTT window could be different for flows with different RTT

--- a/model/utils.py
+++ b/model/utils.py
@@ -40,10 +40,11 @@ def parse_packets_endpoint(flp, packet_size_B):
     """
     # Not using parse_time_us for efficiency purpose
     return [
-        (scapy.layers.ppp.PPP(pkt_dat)[scapy.layers.inet.TCP].seq, pkt_mdat.sec * 1e6 + pkt_mdat.usec)
-            for pkt_dat, pkt_mdat in scapy.utils.RawPcapReader(flp)
+        (scapy.layers.ppp.PPP(pkt_dat)[scapy.layers.inet.TCP].seq,
+         pkt_mdat.sec * 1e6 + pkt_mdat.usec)
+        for pkt_dat, pkt_mdat in scapy.utils.RawPcapReader(flp)
         # Select only IP/TCP packets larger than or equal to packet size.
-        if (pkt_mdat.wirelen >= packet_size_B) # Ignore non-data packets
+        if pkt_mdat.wirelen >= packet_size_B # Ignore non-data packets
         ]
 
 def parse_packets_router(flp, packet_size_B):
@@ -53,10 +54,11 @@ def parse_packets_router(flp, packet_size_B):
     # Not using parse_time_us for efficiency purpose
     return [
         # Parse each packet as a PPP packet.
-        (int(scapy.layers.ppp.PPP(pkt_dat)[scapy.layers.inet.IP].src.split(".")[2]), pkt_mdat.sec * 1e6 + pkt_mdat.usec)
-            for pkt_dat, pkt_mdat in scapy.utils.RawPcapReader(flp)
+        (int(scapy.layers.ppp.PPP(pkt_dat)[scapy.layers.inet.IP].src.split(".")[2]),
+         pkt_mdat.sec * 1e6 + pkt_mdat.usec)
+        for pkt_dat, pkt_mdat in scapy.utils.RawPcapReader(flp)
         # Select only IP/TCP packets larger than or equal to packet size.
-        if (pkt_mdat.wirelen >= packet_size_B) # Ignore non-data packets
+        if pkt_mdat.wirelen >= packet_size_B # Ignore non-data packets
         ]
 
 


### PR DESCRIPTION
Update parse_packets to only return fields of interests

parse_packets_endpoint -> (seq, timestamp)
parse_packets_router     -> (sender, timestamp)

The main improvement comes from removing the intermediate step in parse_packets. 

Parsing a single 80s experiment with 1 unfair sender and 8 other senders.
Memory usage: 1.04G -> 0.13G
Processing time: 52s -> 24s